### PR TITLE
修改登录页输入手机号码的文本框类型

### DIFF
--- a/netease_cloud_music/lib/pages/login_page.dart
+++ b/netease_cloud_music/lib/pages/login_page.dart
@@ -111,6 +111,7 @@ class __LoginWidgetState extends State<_LoginWidget> {
           VEmptyView(50),
           TextField(
             controller: _phoneController,
+            keyboardType: TextInputType.phone,
             decoration: InputDecoration(
                 hintText: 'Phone',
                 prefixIcon: Icon(


### PR DESCRIPTION
登录时，手机号码栏只显示数字键盘。